### PR TITLE
Add AppIntro with notification permission guidance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.appcompat)
+    implementation(libs.appintro)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,11 @@
         </activity>
         
         <activity
+            android:name=".IntroActivity"
+            android:exported="false"
+            android:theme="@style/Theme.LifeCycle.AppCompat" />
+            
+        <activity
             android:name=".MainActivity"
             android:exported="false"
             android:label="@string/app_name"

--- a/app/src/main/java/com/example/lifecycle/IntroActivity.kt
+++ b/app/src/main/java/com/example/lifecycle/IntroActivity.kt
@@ -1,0 +1,79 @@
+package com.example.lifecycle
+
+import android.Manifest
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import androidx.fragment.app.Fragment
+import com.github.appintro.AppIntro2
+import com.github.appintro.AppIntroFragment
+import com.github.appintro.model.SliderPage
+
+class IntroActivity : AppIntro2() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Notification permission slide
+        addSlide(AppIntroFragment.createInstance(
+            SliderPage(
+                title = "Enable Notifications",
+                description = "Allow notifications to see app updates and demonstration features. Tap 'Skip' to open notification settings manually.",
+                imageDrawable = android.R.drawable.ic_popup_reminder,
+                titleColorRes = android.R.color.black,
+                descriptionColorRes = android.R.color.darker_gray,
+                backgroundColorRes = android.R.color.white
+            )
+        ))
+
+        // Request notification permission on Android 13+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            askForPermissions(
+                permissions = arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                slideNumber = 1,
+                required = false
+            )
+        }
+
+        // Hide status bar
+        showStatusBar(false)
+        
+        // Enable skip button
+        isSkipButtonEnabled = true
+    }
+
+    override fun onSkipPressed(currentFragment: Fragment?) {
+        super.onSkipPressed(currentFragment)
+        openNotificationSettings()
+    }
+
+    override fun onDonePressed(currentFragment: Fragment?) {
+        super.onDonePressed(currentFragment)
+        goToMainActivity()
+    }
+
+    private fun openNotificationSettings() {
+        try {
+            val intent = Intent()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                intent.action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                intent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+            } else {
+                intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                intent.data = Uri.parse("package:$packageName")
+            }
+            startActivity(intent)
+        } catch (e: Exception) {
+            // Fallback to main settings if specific settings fail
+            startActivity(Intent(Settings.ACTION_SETTINGS))
+        }
+        goToMainActivity()
+    }
+
+    private fun goToMainActivity() {
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+}

--- a/app/src/main/java/com/example/lifecycle/SplashActivity.kt
+++ b/app/src/main/java/com/example/lifecycle/SplashActivity.kt
@@ -19,7 +19,7 @@ class SplashActivity : Activity() {
         
         splashScreen.setKeepOnScreenCondition { false }
         
-        startActivity(Intent(this, MainActivity::class.java))
+        startActivity(Intent(this, IntroActivity::class.java))
         finish()
     }
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,6 +3,8 @@
 
     <style name="Theme.LifeCycle" parent="android:Theme.Material.Light.NoActionBar" />
 
+    <style name="Theme.LifeCycle.AppCompat" parent="Theme.AppCompat.Light.NoActionBar" />
+
     <style name="Theme.LifeCycle.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@android:color/white</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.0.0"
 coreKtx = "1.16.0"
 splashscreen = "1.0.1"
 appcompat = "1.7.0"
+appintro = "6.3.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
@@ -15,6 +16,7 @@ composeBom = "2024.04.01"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+appintro = { group = "com.github.AppIntro", name = "AppIntro", version.ref = "appintro" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
- Add AppIntro library dependency with JitPack repository
- Create simple single-slide intro focusing on notification permissions
- Implement automatic permission request for Android 13+ devices
- Add Settings button that opens device notification settings
- Create AppCompat theme for proper AppIntro compatibility
- Update navigation flow: Splash → Intro → MainActivity
- Provide clear user guidance for enabling notifications manually
- Simplify onboarding to focus solely on notification setup

The intro provides both automatic permission request and manual settings access, ensuring users can enable notifications regardless of Android version or permission dialog outcome.

🤖 Generated with [Claude Code](https://claude.ai/code)